### PR TITLE
:sparkles: Feat: API v1 공통 prefix 설정

### DIFF
--- a/src/main/java/com/bidweather/backend_core/config/WebConfig.java
+++ b/src/main/java/com/bidweather/backend_core/config/WebConfig.java
@@ -1,0 +1,13 @@
+package com.bidweather.backend_core.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.PathMatchConfigurer;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+    @Override
+    public void configurePathMatch(PathMatchConfigurer configurer) {
+        configurer.addPathPrefix("/api/v1", c -> true);
+    }
+}


### PR DESCRIPTION
- 모든 Controller 요청 경로에 /api/v1 prefix 적용
- WebMvcConfigurer를 사용하여 전역 URL 규칙 설정

Resolves: #1

## 🔗 관련 이슈
- Resolves: #1

## 📝 개요
- 모든 Controller 요청 경로에 /api/v1 prefix를 적용
- WebMvcConfigurer를 사용하여 전역 URL 규칙 설정

## 🧩 PR 유형 (중복 선택 가능)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링 (기능 변경 없음)
- [ ] 문서 수정
- [ ] 테스트 추가 / 리팩토링
- [ ] 빌드 / CI 관련 변경
- [ ] UI / 스타일 개선
- [ ] 기타 (설명 필요)

## ✅ 상세 내용
- /api/v1 prefix를 모든 @RestController 대상에 적용


## 📌 체크리스트
- [x] 커밋 메시지가 컨벤션을 따릅니다. (ex. `:sparkles: Feat: 기능 제목 한 줄 요약`)
- [ ] 로컬에서 기능이 정상적으로 작동하는지 확인했습니다.
- [ ] 주요 변경 사항에 대한 테스트를 추가하거나 수정했고, 테스트가 통과했습니다.
- [ ] 변경된 내용이 문서(README, API 명세서 등)에 반영되었습니다.
- [x] 보안상 민감 정보(API 키, 비밀번호 등)가 포함되지 않았는지 확인했습니다.
- [x] 불필요한 로그, 주석, 사용하지 않는 코드를 제거했습니다.