### PR TITLE
[Feat] 현재 날짜와 시간을 조회하는 API 구현 완료

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,6 +13,12 @@ java {
 	}
 }
 
+configurations {
+	compileOnly {
+		extendsFrom annotationProcessor
+	}
+}
+
 repositories {
 	mavenCentral()
 }
@@ -29,6 +35,8 @@ dependencies {
 	testCompileOnly 'org.projectlombok:lombok'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 	testAnnotationProcessor 'org.projectlombok:lombok'
+
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/bidweather/backend_core/config/WebConfig.java
+++ b/src/main/java/com/bidweather/backend_core/config/WebConfig.java
@@ -1,0 +1,13 @@
+package com.bidweather.backend_core.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.PathMatchConfigurer;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+    @Override
+    public void configurePathMatch(PathMatchConfigurer configurer) {
+        configurer.addPathPrefix("/api/v1", c -> true);
+    }
+}

--- a/src/main/java/com/bidweather/backend_core/controller/SystemController.java
+++ b/src/main/java/com/bidweather/backend_core/controller/SystemController.java
@@ -1,0 +1,21 @@
+package com.bidweather.backend_core.controller;
+
+import com.bidweather.backend_core.dto.response.TimeResponseDto;
+import com.bidweather.backend_core.service.query.SystemQueryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/system")
+@RequiredArgsConstructor
+public class SystemController {
+    private final SystemQueryService systemQueryService;
+
+    @GetMapping("/time")
+    public ResponseEntity<TimeResponseDto> getTime() {
+        return ResponseEntity.ok(systemQueryService.getTime());
+    }
+}

--- a/src/main/java/com/bidweather/backend_core/dto/response/TimeResponseDto.java
+++ b/src/main/java/com/bidweather/backend_core/dto/response/TimeResponseDto.java
@@ -1,0 +1,19 @@
+package com.bidweather.backend_core.dto.response;
+
+import jakarta.validation.constraints.NotNull;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
+
+public record TimeResponseDto(
+        @NotNull
+        LocalDate date,
+
+        @NotNull
+        String time
+) {
+    public static TimeResponseDto fromEntity(LocalDate date, LocalTime time) {
+        return new TimeResponseDto(date, time.format(DateTimeFormatter.ofPattern("HH:mm")));
+    }
+}

--- a/src/main/java/com/bidweather/backend_core/service/query/SystemQueryService.java
+++ b/src/main/java/com/bidweather/backend_core/service/query/SystemQueryService.java
@@ -1,0 +1,16 @@
+package com.bidweather.backend_core.service.query;
+
+import com.bidweather.backend_core.dto.response.TimeResponseDto;
+import jakarta.transaction.Transactional;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+@Service
+@Transactional
+public class SystemQueryService {
+    public TimeResponseDto getTime() {
+        return TimeResponseDto.fromEntity(LocalDate.now(), LocalTime.now());
+    }
+}


### PR DESCRIPTION
## 🔗 관련 이슈
- Resolves: #3

## 📝 개요
- 시스템 현재 시간을 조회하는 API를 구현하여 클라이언트가 서버 시간을 확인할 수 있도록 기능 추가

## 🧩 PR 유형 (중복 선택 가능)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링 (기능 변경 없음)
- [ ] 문서 수정
- [ ] 테스트 추가 / 리팩토링
- [ ] 빌드 / CI 관련 변경
- [ ] UI / 스타일 개선
- [ ] 기타 (설명 필요)

## ✅ 상세 내용
- SystemController에 시간 조회 엔드포인트 추가
- SystemQueryService에서 현재 시간 조회 로직 구현
- TimeResponseDto를 통해 응답 데이터 구조 정의
- LocalTime을 사용하여 시간 처리 후 HH:mm 포맷으로 응답하도록 구성

## 📌 체크리스트
- [x] 커밋 메시지가 컨벤션을 따릅니다. (ex. `:sparkles: Feat: 기능 제목 한 줄 요약`)
- [x] 로컬에서 기능이 정상적으로 작동하는지 확인했습니다.
- [ ] 주요 변경 사항에 대한 테스트를 추가하거나 수정했고, 테스트가 통과했습니다.
- [ ] 변경된 내용이 문서(README, API 명세서 등)에 반영되었습니다.
- [x] 보안상 민감 정보(API 키, 비밀번호 등)가 포함되지 않았는지 확인했습니다.
- [ ] 불필요한 로그, 주석, 사용하지 않는 코드를 제거했습니다.