### PR TITLE
[Feat] 대분류/소분류 응답 DTO에 id 필드 추가

### DIFF
--- a/src/main/java/com/bidweather/backend_core/controller/CategoryController.java
+++ b/src/main/java/com/bidweather/backend_core/controller/CategoryController.java
@@ -1,7 +1,7 @@
 package com.bidweather.backend_core.controller;
 
-import com.bidweather.backend_core.dto.response.CategoryResponseDto;
-import com.bidweather.backend_core.dto.response.SubcategoryResponseDto;
+import com.bidweather.backend_core.dto.response.CategoryListResponseDto;
+import com.bidweather.backend_core.dto.response.SubcategoryListResponseDto;
 import com.bidweather.backend_core.service.query.CategoryQueryService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -17,12 +17,12 @@ public class CategoryController {
     private final CategoryQueryService categoryQueryService;
 
     @GetMapping("")
-    public ResponseEntity<CategoryResponseDto> getCategories() {
+    public ResponseEntity<CategoryListResponseDto> getCategories() {
         return ResponseEntity.ok(categoryQueryService.getAllCategories());
     }
 
     @GetMapping("/{categoryId}/subcategories")
-    public ResponseEntity<SubcategoryResponseDto> getSubcategoriesByCategoryId(@PathVariable Long categoryId) {
+    public ResponseEntity<SubcategoryListResponseDto> getSubcategoriesByCategoryId(@PathVariable Long categoryId) {
         return ResponseEntity.ok(categoryQueryService.getSubcategoriesByCategoryId(categoryId));
     }
 }

--- a/src/main/java/com/bidweather/backend_core/controller/SubcategoryController.java
+++ b/src/main/java/com/bidweather/backend_core/controller/SubcategoryController.java
@@ -1,6 +1,6 @@
 package com.bidweather.backend_core.controller;
 
-import com.bidweather.backend_core.dto.response.SubcategoryResponseDto;
+import com.bidweather.backend_core.dto.response.SubcategoryListResponseDto;
 import com.bidweather.backend_core.service.query.SubcategoryQueryService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -15,7 +15,7 @@ public class SubcategoryController {
     private final SubcategoryQueryService subcategoryQueryService;
 
     @GetMapping("")
-    public ResponseEntity<SubcategoryResponseDto> getSubcategories() {
+    public ResponseEntity<SubcategoryListResponseDto> getSubcategories() {
         return ResponseEntity.ok(subcategoryQueryService.getAllSubcategories());
     }
 }

--- a/src/main/java/com/bidweather/backend_core/dto/response/CategoryListResponseDto.java
+++ b/src/main/java/com/bidweather/backend_core/dto/response/CategoryListResponseDto.java
@@ -1,0 +1,18 @@
+package com.bidweather.backend_core.dto.response;
+
+import com.bidweather.backend_core.domain.Category;
+
+import java.util.List;
+
+public record CategoryListResponseDto(
+        List<CategoryResponseDto> categories
+) {
+    public record CategoryResponseDto(
+            Long id,
+            String categoryName
+    ) {
+        public static CategoryResponseDto from(Category category) {
+            return new CategoryResponseDto(category.getId(), category.getCategoryName());
+        }
+    }
+}

--- a/src/main/java/com/bidweather/backend_core/dto/response/CategoryResponseDto.java
+++ b/src/main/java/com/bidweather/backend_core/dto/response/CategoryResponseDto.java
@@ -1,8 +1,0 @@
-package com.bidweather.backend_core.dto.response;
-
-import java.util.List;
-
-public record CategoryResponseDto<T>(
-        List<T> categories
-) {
-}

--- a/src/main/java/com/bidweather/backend_core/dto/response/SubcategoryListResponseDto.java
+++ b/src/main/java/com/bidweather/backend_core/dto/response/SubcategoryListResponseDto.java
@@ -1,0 +1,18 @@
+package com.bidweather.backend_core.dto.response;
+
+import com.bidweather.backend_core.domain.Subcategory;
+
+import java.util.List;
+
+public record SubcategoryListResponseDto(
+        List<SubcategoryResponseDto> subcategories
+) {
+    public record SubcategoryResponseDto(
+            Long id,
+            String subcategoryName
+    ) {
+        public static SubcategoryResponseDto from(Subcategory subcategory) {
+            return new SubcategoryResponseDto(subcategory.getId(), subcategory.getSubcategoryName());
+        }
+    }
+}

--- a/src/main/java/com/bidweather/backend_core/dto/response/SubcategoryResponseDto.java
+++ b/src/main/java/com/bidweather/backend_core/dto/response/SubcategoryResponseDto.java
@@ -1,8 +1,0 @@
-package com.bidweather.backend_core.dto.response;
-
-import java.util.List;
-
-public record SubcategoryResponseDto<T>(
-        List<T> subcategories
-) {
-}

--- a/src/main/java/com/bidweather/backend_core/repository/CategorySubcategoryRepository.java
+++ b/src/main/java/com/bidweather/backend_core/repository/CategorySubcategoryRepository.java
@@ -1,0 +1,18 @@
+package com.bidweather.backend_core.repository;
+
+import com.bidweather.backend_core.domain.CategorySubcategory;
+import com.bidweather.backend_core.domain.Subcategory;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
+
+public interface CategorySubcategoryRepository extends JpaRepository<CategorySubcategory, Long> {
+
+    @Query("""
+        SELECT cs.subcategory
+        FROM CategorySubcategory cs
+        WHERE cs.category.id = :categoryId
+    """)
+    List<Subcategory> findSubcategoriesByCategoryId(Long categoryId);
+}

--- a/src/main/java/com/bidweather/backend_core/service/query/CategoryQueryService.java
+++ b/src/main/java/com/bidweather/backend_core/service/query/CategoryQueryService.java
@@ -1,39 +1,36 @@
 package com.bidweather.backend_core.service.query;
 
-import com.bidweather.backend_core.domain.Category;
-import com.bidweather.backend_core.domain.CategorySubcategory;
-import com.bidweather.backend_core.domain.Subcategory;
-import com.bidweather.backend_core.dto.response.CategoryResponseDto;
-import com.bidweather.backend_core.dto.response.SubcategoryResponseDto;
+import com.bidweather.backend_core.dto.response.CategoryListResponseDto;
+import com.bidweather.backend_core.dto.response.SubcategoryListResponseDto;
 import com.bidweather.backend_core.repository.CategoryRepository;
+import com.bidweather.backend_core.repository.CategorySubcategoryRepository;
+import com.bidweather.backend_core.repository.SubcategoryRepository;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
-import java.util.NoSuchElementException;
 
 @Service
 @Transactional
 @RequiredArgsConstructor
 public class CategoryQueryService {
     private final CategoryRepository categoryRepository;
+    private final CategorySubcategoryRepository categorySubcategoryRepository;
 
-    public CategoryResponseDto<String> getAllCategories() {
-        List<String> categoryNames = categoryRepository.findAll().stream()
-                .map(Category::getCategoryName)
+    public CategoryListResponseDto getAllCategories() {
+        List<CategoryListResponseDto.CategoryResponseDto> categories = categoryRepository.findAll()
+                .stream()
+                .map(CategoryListResponseDto.CategoryResponseDto::from)
                 .toList();
-        return new CategoryResponseDto<>(categoryNames);
+        return new CategoryListResponseDto(categories);
     }
 
-    public SubcategoryResponseDto<String> getSubcategoriesByCategoryId(Long categoryId) {
-        Category category = categoryRepository.findById(categoryId).orElseThrow(() -> new NoSuchElementException());
-
-        List<String> subcategories = category.getCategorySubcategories().stream()
-                .map(CategorySubcategory::getSubcategory)
-                .map(Subcategory::getSubcategoryName)
+    public SubcategoryListResponseDto getSubcategoriesByCategoryId(Long categoryId) {
+        List<SubcategoryListResponseDto.SubcategoryResponseDto> subcategories = categorySubcategoryRepository.findSubcategoriesByCategoryId(categoryId)
+                .stream()
+                .map(SubcategoryListResponseDto.SubcategoryResponseDto::from)
                 .toList();
-
-        return new SubcategoryResponseDto<>(subcategories);
+        return new SubcategoryListResponseDto(subcategories);
     }
 }

--- a/src/main/java/com/bidweather/backend_core/service/query/SubcategoryQueryService.java
+++ b/src/main/java/com/bidweather/backend_core/service/query/SubcategoryQueryService.java
@@ -1,7 +1,6 @@
 package com.bidweather.backend_core.service.query;
 
-import com.bidweather.backend_core.domain.Subcategory;
-import com.bidweather.backend_core.dto.response.SubcategoryResponseDto;
+import com.bidweather.backend_core.dto.response.SubcategoryListResponseDto;
 import com.bidweather.backend_core.repository.SubcategoryRepository;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
@@ -15,10 +14,11 @@ import java.util.List;
 public class SubcategoryQueryService {
     private final SubcategoryRepository subcategoryRepository;
 
-    public SubcategoryResponseDto<String> getAllSubcategories() {
-        List<String> subcategoryNames = subcategoryRepository.findAll().stream()
-                .map(Subcategory::getSubcategoryName)
+    public SubcategoryListResponseDto getAllSubcategories() {
+        List<SubcategoryListResponseDto.SubcategoryResponseDto> subcategories = subcategoryRepository.findAll()
+                .stream()
+                .map(SubcategoryListResponseDto.SubcategoryResponseDto::from)
                 .toList();
-        return new SubcategoryResponseDto<>(subcategoryNames);
+        return new SubcategoryListResponseDto(subcategories);
     }
 }

--- a/src/main/resources/db/migration/V21__delete_category_subcategory_duplication.sql
+++ b/src/main/resources/db/migration/V21__delete_category_subcategory_duplication.sql
@@ -1,0 +1,8 @@
+DELETE FROM category_subcategory a
+WHERE EXISTS (
+    SELECT 1
+    FROM category_subcategory b
+    WHERE a.id > b.id
+      AND a.category_id = b.category_id
+      AND a.subcategory_id = b.subcategory_id
+);


### PR DESCRIPTION
## 🔗 관련 이슈
- Resolves: #19

## 📝 개요
- 카테고리 및 소분류 조회 API 응답에 id 필드가 없어 클라이언트에서 categoryId, subcategoryId를 필터 파라미터로 전달할 수 없는 문제를 해결
- 응답 DTO에 id 필드를 추가하고 리스트 래퍼 DTO를 신규 생성하여 클라이언트가 드롭다운 선택 시 id를 함께 저장하고 예측 캘린더/그래프 조회 필터에 활용할 수 있도록 개선

## 🧩 PR 유형 (중복 선택 가능)
- [x] 기능 추가
- [ ] 버그 수정
- [x] 리팩토링 (기능 변경 없음)
- [ ] 문서 수정
- [ ] 테스트 추가 / 리팩토링
- [ ] 빌드 / CI 관련 변경
- [ ] UI / 스타일 개선
- [ ] 기타 (설명 필요)

## ✅ 상세 내용

### DTO
- `CategoryListResponseDto` 신규 생성 —-`List<CategoryResponseDto>` 래핑
- `SubcategoryListResponseDto` 신규 생성 - `List<SubcategoryResponseDto>` 래핑
- 기존 `CategoryResponseDto`, `SubcategoryResponseDto` 삭제 후 래퍼 클래스 내에 `id` 필드 포함 구조로 재설계

### Repository
- `CategorySubcategoryRepository` 신규 추가
- 대분류 ID 기반 소분류 목록 조회 책임 분리

### Service
- `CategoryQueryService` 반환 타입을 `CategoryListResponseDto`로 변경
- `SubcategoryQueryService` 반환 타입을 `SubcategoryListResponseDto`로 변경

### Controller
- `CategoryController` ResponseEntity 제네릭 타입을 `CategoryListResponseDto` 추가
- `SubcategoryController` ResponseEntity 제네릭 타입을 `SubcategoryListResponseDto` 추가


## 📌 체크리스트
- [x] 커밋 메시지가 컨벤션을 따릅니다. (ex. `:sparkles: Feat: 기능 제목 한 줄 요약`)
- [x] 로컬에서 기능이 정상적으로 작동하는지 확인했습니다.
- [ ] 주요 변경 사항에 대한 테스트를 추가하거나 수정했고, 테스트가 통과했습니다.
- [ ] 변경된 내용이 문서(README, API 명세서 등)에 반영되었습니다.
- [x] 보안상 민감 정보(API 키, 비밀번호 등)가 포함되지 않았는지 확인했습니다.
- [x] 불필요한 로그, 주석, 사용하지 않는 코드를 제거했습니다.